### PR TITLE
[10] 순환 참조 에러 해결

### DIFF
--- a/src/main/java/com/project/reference/CheckWalletReference.java
+++ b/src/main/java/com/project/reference/CheckWalletReference.java
@@ -4,7 +4,6 @@ import com.project.exception.CustomException;
 import com.project.user.entity.User;
 import com.project.wallet.entity.Wallet;
 import com.project.wallet.repository.WalletRepository;
-import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -14,18 +13,9 @@ import static com.project.exception.ErrorCode.INVALID_WALLET;
 @RequiredArgsConstructor
 public class CheckWalletReference {
     private final WalletRepository walletRepository;
-    private final CheckUserReference checkUserReference;
 
     public Wallet findWalletByUser(User user) {
         return walletRepository.findByUser(user)
                 .orElseThrow(() -> new CustomException(INVALID_WALLET));
-    }
-
-    public Wallet findWalletByRequestHeader(HttpServletRequest request) {
-        String email = checkUserReference.checkUserReference(request);
-
-        User user = checkUserReference.findUserByEmail(email);
-
-        return findWalletByUser(user);
     }
 }


### PR DESCRIPTION
`CheckWalletReference` 내 `CheckUserReference` 순환 참조되는 코드 삭제