### PR TITLE
[012] PasswordEncoder 분리

### DIFF
--- a/src/main/java/com/project/configuration/security/PasswordEncodeConfig.java
+++ b/src/main/java/com/project/configuration/security/PasswordEncodeConfig.java
@@ -1,0 +1,13 @@
+package com.project.configuration.security;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+
+@Configuration
+public class PasswordEncodeConfig {
+    @Bean
+    public BCryptPasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+}

--- a/src/main/java/com/project/configuration/security/SecurityConfig.java
+++ b/src/main/java/com/project/configuration/security/SecurityConfig.java
@@ -19,11 +19,6 @@ public class SecurityConfig {
     private final JwtToken jwtToken;
 
     @Bean
-    public BCryptPasswordEncoder passwordEncoder() {
-        return new BCryptPasswordEncoder();
-    }
-
-    @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         http
                 .csrf(AbstractHttpConfigurer::disable)


### PR DESCRIPTION
## why ?
#12 에서 순환 참조가 Local 에서는 에러가 뜨지 않았지만, 배포 서버 내 반복 발생
- 원인 확인이 어려워서 예상 원인 하나씩 제거
- `SecurityConfig` 내 PasswordEncoder 단일 클래스로 분리
