### PR TITLE
[014] Deprecated method 제거

### DIFF
--- a/src/main/java/com/project/configuration/security/CustomFilter.java
+++ b/src/main/java/com/project/configuration/security/CustomFilter.java
@@ -6,6 +6,7 @@ import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -15,6 +16,7 @@ import java.io.IOException;
 
 import static com.project.exception.ErrorCode.LOGIN_FAIL;
 
+@Configuration
 @RequiredArgsConstructor
 public class CustomFilter extends OncePerRequestFilter {
     private final UserDetailsServiceImpl userDetailsService;
@@ -25,7 +27,7 @@ public class CustomFilter extends OncePerRequestFilter {
         String accessToken = jwtToken.getAccessTokenFromRequest(request);
 
         if (accessToken != null && jwtToken.isValidToken(accessToken)) {
-            String email = jwtToken.getPayloadSub(accessToken);
+            String email = jwtToken.getPayloadEmail(accessToken);
             Authentication authentication = getAuthentication(email);
 
             SecurityContextHolder.getContext().setAuthentication(authentication);

--- a/src/main/java/com/project/exception/ErrorCode.java
+++ b/src/main/java/com/project/exception/ErrorCode.java
@@ -13,6 +13,7 @@ public enum ErrorCode {
     DUPLICATED_NICKNAME(HttpStatus.BAD_REQUEST, "중복된 닉네임입니다."),
     UNMATCHED_PASSWORD(HttpStatus.BAD_REQUEST, "비밀번호가 일치하지 않습니다."),
     LOGIN_FAIL(HttpStatus.BAD_REQUEST, "로그인에 실패했습니다."),
+    INVALID_TOKEN(HttpStatus.BAD_REQUEST, "유효하지 않은 토큰입니다"),
 
     // WebSocket
     WEBSOCKET_CLOSED(HttpStatus.BAD_REQUEST, "서버가 닫혀있습니다."),

--- a/src/main/java/com/project/reference/CheckUserReference.java
+++ b/src/main/java/com/project/reference/CheckUserReference.java
@@ -49,6 +49,6 @@ public class CheckUserReference {
 
     public String checkUserReference(HttpServletRequest request) {
         String token = request.getHeader("Authorization").replace("Bearer ", "");
-        return jwtToken.getPayloadSub(token);
+        return jwtToken.getPayloadEmail(token);
     }
 }


### PR DESCRIPTION
두 deprecated method 제거
### AS IS
```java
public String generateAccessToken (String email) { // accessToken 생성
        Date date = new Date();
        return Jwts.builder()
                .setSubject(ACCESS_TOKEN)
                .setExpiration(new Date(date.getTime() + ACCESS_TOKEN_EXPIRATION_PERIOD))
                .claim("email", email)
                .signWith(SignatureAlgorithm.HS256, jwtKey)
                .compact();
    }

public String getPayloadSub(String token) { 
        return Jwts.parser()
                .setSigningKey(jwtKey)
                .parseClaimsJws(token)
                .getBody()
                .getSubject();
    }
``` 
### TO BE
```java
public String generateAccessToken(String email) { // accessToken 생성
        Date date = new Date();
        return JWT.create()
                .withSubject(ACCESS_TOKEN)
                .withExpiresAt(new Date(date.getTime() + ACCESS_TOKEN_EXPIRATION_PERIOD))
                .withClaim(EMAIL, email)
                .sign(Algorithm.HMAC256(jwtKey));
    }

public String getPayloadEmail(String token) {
        try {
            return JWT.require(Algorithm.HMAC256(jwtKey))
                    .build()
                    .verify(token)
                    .getClaim(EMAIL)
                    .asString();
        } catch (Exception e) {
            throw new CustomException(INVALID_TOKEN);
        }
    }
``` 